### PR TITLE
99% of server overload errors are gone

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,7 @@ COPY . .
 
 # Install app dependencies
 RUN npm install
+RUN npm install react-dropzone
 
 # Expose a port to communicate with the React app
 EXPOSE 4000

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
     "postcss": "^8.4.39",
+    "react-dropzone": "^14.2.10",
     "tailwindcss": "^3.4.4",
     "vite": "^5.3.1"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.1",
     "react-router-dom": "^6.24.1",
+    "react-dropzone": "^14.2.10",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.4.0",
     "tailwind-scrollbar": "^3.1.0",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -86,9 +86,10 @@ export const getProfileAuth = async (username) => {
     return userInfo;
 };
 
-export const getPics = async (username) => {
-    const apiUrl = `${API_URL}/image/get`;
-    return fetcher(apiUrl, { username }, 'POST');
+export const getUserPics = async (username) => {
+    const response = await fetcher(`${API_URL}/image/get`, { username}, 'POST');
+    if (response.error) throw new Error(response.error);
+    return response.code ? [] : response;
 };
 
 export const updateProfile = async ({ profileUsername, viewer, newUserData }) => {
@@ -117,9 +118,8 @@ export const uploadProfilePicture = async ({ username, file }) => {
     return fetcher(apiUrl, { username, file }, 'POST');
 };
 
-export const deleteProfilePicture = async ({ username, imageName }) => {
+export const deleteProfilePicture = async ({ username, imageNumber }) => {
     const apiUrl = `${API_URL}/image/delete`;
-    const imageNumber = imageName.split('_')[1].split('.')[0];
     return fetcher(apiUrl, { username, imageNumber }, 'DELETE');
 };
 

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -43,11 +43,15 @@ const FileUpload = ({ username }) => {
     onError: (error, variables, context) => {
       queryClient.setQueryData(['pics', username], context.previousPics);
       console.error('Error uploading picture:', error);
+      setSelectedFile(null);
     },
     onSuccess: (data) => {
       if (data.imageNumber === 1) {
         setMain(data.imageName);
       }
+    },
+    onSettled: () => {
+      setSelectedFile(null);
     },
     enabled: Boolean(username),
   });

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -13,7 +13,7 @@ const encodeImageAsBase64 = (file) => {
   });
 };
 
-const FileUpload = ({ username }) => {
+const FileUpload = ({ username, setMain }) => {
   const queryClient = useQueryClient();
   const [selectedFile, setSelectedFile] = useState(null);
   const [uploading, setUploading] = useState(false);
@@ -54,6 +54,7 @@ const FileUpload = ({ username }) => {
       setSelectedFile(null);
     },
     enabled: Boolean(username),
+    retry: 4
   });
 
   const validateFile = useCallback((file) => {
@@ -75,9 +76,10 @@ const FileUpload = ({ username }) => {
     if (validateFile(file)) {
       const img = new Image();
       img.src = URL.createObjectURL(file);
-      img.onload = () => {
+      img.onload = async () => {
         if (img.width < 12000 && img.height < 12000) {
-          setSelectedFile(file);
+          const imageString = await encodeImageAsBase64(file);
+          setSelectedFile(imageString);
         } else {
           setError("Image dimensions must be 1200x1200px or less");
         }
@@ -90,8 +92,8 @@ const FileUpload = ({ username }) => {
     if (!selectedFile) return;
     setUploading(true);
     try {
-      const imageString = await encodeImageAsBase64(selectedFile);
-      picsMutation.mutate({ username, file: imageString });
+      // const imageString = await encodeImageAsBase64(selectedFile);
+      picsMutation.mutate({ username, file: selectedFile });
     } catch (error) {
       console.error("File encoding error:", error);
     } finally {

--- a/frontend/src/components/PicGallery.jsx
+++ b/frontend/src/components/PicGallery.jsx
@@ -1,115 +1,126 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import FileUpload from '@/components/FileUpload';
-import { deleteProfilePicture, changeMainPicture } from '@/api';
+import CustomLayout from '@/components/MatchaLayout';
+import { deleteProfilePicture, changeMainPicture, getUserPics, getProfileAuth } from '@/api';
 import { PicItem } from '@/components/PicItem';
+// import { useAuthStatus } from '@/hooks/useAuthStatus';
 
-const PicGallery = ({ profileUsername, mainpic, pics }) => {
-  const [main, setMain] = useState(mainpic);
+const PicGallery = ({username, mainpic}) => {
   const queryClient = useQueryClient();
+  // const { user } = useAuthStatus();
+  // const username = user?.username;
+  const [main, setMain] = useState(mainpic);
 
+  const { data: pics, isLoading } = useQuery({
+    queryKey: ['pics', username],
+    queryFn: () => getUserPics(username),
+    enabled: !!username,
+    onError: (err) => console.log('pics error', err),
+    onSettled: () => {
+      setMain(mainpic);
+    }
+  });
+
+  // Optimistic update for deleting a picture
   const deletePicMutation = useMutation({
     mutationFn: deleteProfilePicture,
-    onMutate: async ({ username, imageName }) => {
-      await queryClient.cancelQueries(['userData', username, username]);
-      const previousUserData = queryClient.getQueryData(['userData', username, username]);
+    onMutate: async ({ imageName, imageIndex }) => {
+      await queryClient.cancelQueries(['pics', username]);
+      
+      const previousPics = queryClient.getQueryData(['pics', username]);
 
-      queryClient.setQueryData(['userData', username, username], old => {
-        const updatedPics = old.displayUser.pics.filter(pic => pic.imageName !== imageName);
-        const deletedIndex = old.displayUser.pics.findIndex(pic => pic.imageName === imageName);
-        
-        let newMainIndex = old.displayUser.pics.findIndex(pic => pic.imageName === old.displayUser.picture_path);
-        if (newMainIndex === deletedIndex) {
-          newMainIndex = updatedPics.length > 0 ? 0 : -1;
-        } else if (newMainIndex > deletedIndex) {
-          newMainIndex--;
-        }
-
-        const renamedPics = updatedPics.map((pic, index) => ({
-          ...pic,
-          imageName: `${username}_${index + 1}.png`,
-          isMain: index === newMainIndex
-        }));
-
-        return {
-          ...old,
-          displayUser: {
-            ...old.displayUser,
-            pics: renamedPics,
-            picture_path: newMainIndex !== -1 ? renamedPics[newMainIndex].imageName : null // Update picture_path
+      const optimisticPics = previousPics
+        .filter(pic => pic.imageName !== imageName)
+        .map(pic => {
+          const currentIndex = parseInt(pic.imageName.match(/_(\d+)\.png$/)[1], 10);
+          if (currentIndex > imageIndex) {
+            return { ...pic, imageName: `${username}_${currentIndex - 1}.png` };
           }
-        };
-      });
+          return pic;
+        });
 
-      return { previousUserData };
+      let newMain = main;
+      if (main === imageName) {
+        newMain = optimisticPics[0]?.imageName || null;
+      } else if (parseInt(main.match(/_(\d+)\.png$/)[1], 10) > imageIndex) {
+        newMain = `${username}_${parseInt(main.match(/_(\d+)\.png$/)[1], 10) - 1}.png`;
+      }
+      setMain(newMain);
+      queryClient.setQueryData(['pics', username], optimisticPics);
+
+      return { previousPics, previousMain: main };
     },
     onError: (err, variables, context) => {
-      console.log('delete pic error vars', variables);
-      queryClient.setQueryData(['userData', variables.username, variables.username], context.previousUserData);
+      queryClient.setQueryData(['pics', username], context.previousPics);
+      setMain(context.previousMain);
     },
-    onSettled: (data, error, { username }) => {
-      queryClient.invalidateQueries(['userData', username, username]);
+    onSettled: () => {
+      // queryClient.invalidateQueries(['pics', username], { refetchInactive: false });
     },
   });
 
+  // Optimistic update for setting main picture
   const changeMainPicMutation = useMutation({
     mutationFn: changeMainPicture,
-    onMutate: async ({ username, image }) => {
-      await queryClient.cancelQueries(['userData', username, username]);
-      const previousUserData = queryClient.getQueryData(['userData', username, username]);
-
-      queryClient.setQueryData(['userData', username, username], old => {
-        const updatedPics = old.displayUser.pics.map(pic => ({
+    onMutate: async ({ image }) => {
+      await queryClient.cancelQueries(['pics', username]);
+      const previousPics = queryClient.getQueryData(['pics', username]);
+      
+      queryClient.setQueryData(['pics', username], old => 
+        old.map(pic => ({
           ...pic,
-          isMain: pic.imageName === image
-        }));
-        return {
-          ...old,
-          displayUser: {
-            ...old.displayUser,
-            pics: updatedPics,
-            picture_path: image // Update picture_path to the new main picture
-          }
-        };
-      });
-
-      return { previousUserData };
+          isMain: pic.imageName === image,
+        }))
+      );
+      
+      return { previousPics };
     },
     onError: (err, variables, context) => {
-      queryClient.setQueryData(['userData', variables.username, variables.username], context.previousUserData);
-    },
-    onSettled: (data, error, { username }) => {
-      queryClient.invalidateQueries(['userData', username, username]);
+      queryClient.setQueryData(['pics', username], context.previousPics);
     },
   });
 
+  // Handlers
   const handleDeletePic = useCallback((imageName) => {
-    const imageNumber = parseInt(imageName.split('_')[1].split('.')[0], 10);
-    deletePicMutation.mutate({ username: profileUsername, imageName, imageNumber });
-  }, [deletePicMutation, profileUsername]);
+    const imageNumber = parseInt(imageName.match(/_(\d+)\.png$/)[1], 10);
+    deletePicMutation.mutate({ username, imageName, imageNumber })
+  }, [deletePicMutation]);
 
   const handleSetMainPic = useCallback((imageName) => {
-    setMain(imageName); // Update local state for main picture
-    changeMainPicMutation.mutate({ username: profileUsername, image: imageName });
-  }, [changeMainPicMutation, profileUsername]);
+    setMain(imageName);
+    changeMainPicMutation.mutate({ username, image: imageName });
+  }, [changeMainPicMutation]);
 
-  useEffect(() => {
-    setMain(mainpic);
-  }, [mainpic]);
+  // Initialize main picture only once
+  // useEffect(() => {
+  //   if (reducedData?.displayUser?.picture_path && !main) {
+  //     setMain(reducedData.displayUser.picture_path);
+  //   }
+  // }, [reducedData, main]);
+
+  // if (isLoadingData) return <div>Loading...</div>;
+  // if (error) return <div>Error: {error.message}</div>;
 
   return (
-    <div className="grid grid-cols-3 gap-4 mt-4"> 
-      {pics?.map((pic) => (
-        <PicItem 
-          key={pic.imageName} 
-          pic={pic} 
-          onDelete={handleDeletePic} 
-          onSetMain={handleSetMainPic}
-          isMainPicture={pic.imageName === main}
-        />
-      ))}
-      <FileUpload username={profileUsername} />
-    </div>
+    <CustomLayout>
+      {isLoading ? (
+        <div className="h-48 w-full rounded-lg bg-gray-200 animate-pulse">Loading</div>
+      ) : (
+        <div className="flex flex-row flex-wrap justify-center gap-4">
+          {pics?.map((pic) => (
+            <PicItem
+              key={pic.imageName} 
+              pic={pic} 
+              onDelete={handleDeletePic} 
+              onSetMain={() => handleSetMainPic(pic.imageName)}
+              isMainPicture={pic.imageName === main}
+            />
+          ))}
+        </div>
+      )}
+      <FileUpload username={username} />
+    </CustomLayout>
   );
 };
 

--- a/frontend/src/components/PicGallery2.jsx
+++ b/frontend/src/components/PicGallery2.jsx
@@ -1,3 +1,124 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import FileUpload from '@/components/FileUpload';
+import CustomLayout from '@/components/MatchaLayout';
+import { deleteProfilePicture, changeMainPicture, getUserPics, getProfileAuth } from '@/api';
+import { PicItem } from '@/components/PicItem';
+import { useAuthStatus } from '@/components/providers/AuthProvider';
+
+const PicGallery = ({mainpic}) => {
+  const queryClient = useQueryClient();
+  const { user } = useAuthStatus();
+  const username = user?.username || '';
+  // const [username, setUsername] = useState(user?.username);
+  const [main, setMain] = useState(null);
+
+  const { data: pics, isLoading } = useQuery({
+    queryKey: ['pics', username],
+    queryFn: () => getUserPics(username),
+    enabled: !!username,
+    onError: (err) => console.log('pics error', err),
+  });
+
+  // Optimistic update for deleting a picture
+  const deletePicMutation = useMutation({
+    mutationFn: deleteProfilePicture,
+    onMutate: async ({ imageName, imageIndex }) => {
+      await queryClient.cancelQueries(['pics', username]);
+      const previousPics = queryClient.getQueryData(['pics', username]);
+      const optimisticPics = previousPics
+        .filter(pic => pic.imageName !== imageName)
+        .map(pic => {
+          const currentIndex = parseInt(pic.imageName.match(/_(\d+)\.png$/)[1], 10);
+          if (currentIndex > imageIndex) {
+            return { ...pic, imageName: `${username}_${currentIndex - 1}.png` };
+          }
+          return pic;
+        });
+
+      let newMain = main;
+      if (main === imageName) {
+        newMain = optimisticPics[0]?.imageName || null;
+      } else if (parseInt(main.match(/_(\d+)\.png$/)[1], 10) > imageIndex) {
+        newMain = `${username}_${parseInt(main.match(/_(\d+)\.png$/)[1], 10) - 1}.png`;
+      }
+      setMain(newMain);
+      queryClient.setQueryData(['pics', username], optimisticPics);
+
+      return { previousPics, previousMain: main };
+    },
+    onError: (err, variables, context) => {
+      queryClient.setQueryData(['pics', username], context.previousPics);
+      setMain(context.previousMain);
+    },
+    onSettled: () => {
+      // queryClient.invalidateQueries(['pics', username], { refetchInactive: false });
+    },
+  });
+
+  // Optimistic update for setting main picture
+  const changeMainPicMutation = useMutation({
+    mutationFn: changeMainPicture,
+    onMutate: async ({ image }) => {
+      await queryClient.cancelQueries(['pics', username]);
+      const previousPics = queryClient.getQueryData(['pics', username]);
+      
+      queryClient.setQueryData(['pics', username], old => 
+        old.map(pic => ({
+          ...pic,
+          isMain: pic.imageName === image,
+        }))
+      );
+      
+      return { previousPics };
+    },
+    onError: (err, variables, context) => {
+      queryClient.setQueryData(['pics', username], context.previousPics);
+    },
+  });
+
+  // Handlers
+  const handleDeletePic = useCallback((imageName) => {
+    const imageNumber = parseInt(imageName.match(/_(\d+)\.png$/)[1], 10);
+    deletePicMutation.mutate({ username, imageName, imageNumber })
+  }, [deletePicMutation]);
+
+  const handleSetMainPic = useCallback((imageName) => {
+    setMain(imageName);
+    changeMainPicMutation.mutate({ username, image: imageName });
+  }, [changeMainPicMutation]);
+
+  // Initialize main picture only once
+  useEffect(() => {
+    if (mainpic && !main) {
+      setMain(mainpic);
+    }
+  }, [reducedData, main]);
+
+  return (
+    <CustomLayout>
+      {isLoading ? (
+        <div className="h-48 w-full rounded-lg bg-gray-200 animate-pulse">Loading</div>
+      ) : (
+        <div className="flex flex-row flex-wrap justify-center gap-4">
+          {pics?.map((pic) => (
+            <PicItem
+              key={pic.imageName} 
+              pic={pic} 
+              onDelete={handleDeletePic} 
+              onSetMain={() => handleSetMainPic(pic.imageName)}
+              isMainPicture={pic.imageName === main}
+            />
+          ))}
+        </div>
+      )}
+      <FileUpload username={username} />
+    </CustomLayout>
+  );
+};
+
+export default PicGallery;
+
 import React, { useState, useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from "@/components/ui/button";
@@ -49,7 +170,6 @@ const FileUpload = ({ username }) => {
         setMain(data.imageName);
       }
     },
-    enabled: Boolean(username),
   });
 
   const validateFile = useCallback((file) => {
@@ -97,7 +217,7 @@ const FileUpload = ({ username }) => {
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
-    accept: {'image/*' : ['.png']},
+    accept: 'image/png',
     multiple: false,
     maxSize: 5 * 1024 * 1024,
   });

--- a/frontend/src/components/PicItem.jsx
+++ b/frontend/src/components/PicItem.jsx
@@ -1,39 +1,19 @@
 import React from 'react';
 import { MoreVertical, Trash, Star } from 'lucide-react';
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 
 export const PicItem = React.memo(({ pic, onDelete, onSetMain, isMainPicture }) => {
   return (
-    <div className="relative group">
+    <div onClick={() => {!isMainPicture && onSetMain(pic.imageName)}} className="relative flex items-center justify-center">
       <img
         src={`data:image/jpeg;base64,${pic.image}`}
         alt={pic.imageName}
         className={`object-cover w-56 h-48 ${isMainPicture ? 'border-4 border-blue-500' : ''}`}
       />
-      <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-8 w-8 p-0">
-              <MoreVertical className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="bg-white/90 dark:bg-gray-800/90 text-black dark:text-white">
-            <DropdownMenuItem onClick={() => onDelete(pic.imageName)} className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-red-600 dark:text-red-400">
-              Delete
-            </DropdownMenuItem>
-            {!isMainPicture && (
-              <DropdownMenuItem onClick={() => onSetMain(pic.imageName)} className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700">
-                Set as main picture
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+      <div className="absolute top-2 right-2 opacity-100 group-hover:opacity-100 transition-opacity">
+        <Button onClick={() => onDelete(pic.imageName)} variant="ghost" className="h-8 w-8 p-0">
+          <Trash className="h-4 w-4" />
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/hooks/useAuthStatus.js
+++ b/frontend/src/hooks/useAuthStatus.js
@@ -9,6 +9,7 @@ export const useAuthStatus = () => {
     queryFn: () => fetcher(`${API_URL}/user/whoami`, {}, 'GET'),
     staleTime: 1000 * 60 * 5,
     refetchOnWindowFocus: false,
+    delay: 1000,
   });
 
   const isAuthenticated = data?.success === true;

--- a/frontend/src/hooks/useAuthStatus.js
+++ b/frontend/src/hooks/useAuthStatus.js
@@ -9,7 +9,7 @@ export const useAuthStatus = () => {
     queryFn: () => fetcher(`${API_URL}/user/whoami`, {}, 'GET'),
     staleTime: 1000 * 60 * 5,
     refetchOnWindowFocus: false,
-    delay: 1000,
+    // delay: 1000,
   });
 
   const isAuthenticated = data?.success === true;

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -18,6 +18,8 @@ export const useNotifications = () => {
     enabled: !!username,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
+    delay: 1200,
+    retryDelay: 1000,
   });
 
   useEffect(() => {

--- a/frontend/src/hooks/useUserData.js
+++ b/frontend/src/hooks/useUserData.js
@@ -10,5 +10,11 @@ export const useUserData = (profileUsername) => {
     queryFn: () => getUserInfo(profileUsername, user?.username),
     enabled: Boolean(profileUsername) && Boolean(user?.username) && !!isAuthenticated,
     staleTime: 60 * 1000,
+    delay: 800,
+    cachingTime: 60 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnFocus: false,
   });
 };

--- a/frontend/src/pages/member/Profile.jsx
+++ b/frontend/src/pages/member/Profile.jsx
@@ -90,7 +90,7 @@ const ProfilePage = () => {
                   <div className="flex justify-center">
                     {(isSelf && !isLoading && !error) ? (
                         <div className='space-y-4'>
-                          <PicGallery profileUsername={profileUsername} mainpic={displayUser?.picture_path} pics={displayUser?.pics}/>
+                          <PicGallery username={profileUsername} mainpic={displayUser?.picture_path}/>
                         </div> ) : ((displayUser?.picture_path && displayUser?.pics.length > 0) && (
                           <div className='w-48 h-48 rounded-full overflow-hidden'>
                             <img


### PR DESCRIPTION
I'm relying mostly on correct optimistic updates that reflect server state now, and invalidating less.
the invalidateQueries calls are triggering chains of re-renders for many query caches, overloading the server and causing batches of requests to fail, which I've reduced down to almost zero.
In certain cases picture mutations will still fail for reasons unknown, but the retry: 4 parameter of the query is more than enough to make the mutation still work, as it will retry moments later and work.